### PR TITLE
Fix runtime error by downgrading @noble/hashes and adding polyfills

### DIFF
--- a/client/lib/solana-derivation.ts
+++ b/client/lib/solana-derivation.ts
@@ -1,5 +1,5 @@
-import { hmac } from "@noble/hashes/hmac.js";
-import { sha512 } from "@noble/hashes/sha512.js";
+import { hmac } from "@noble/hashes/hmac";
+import { sha512 } from "@noble/hashes/sha512";
 
 const HARDENED_OFFSET = 0x80000000;
 const MASTER_SECRET = new TextEncoder().encode("ed25519 seed");

--- a/client/polyfills.ts
+++ b/client/polyfills.ts
@@ -1,0 +1,10 @@
+import { Buffer } from "buffer";
+import process from "process";
+
+// Ensure Node-like globals for browser bundles that expect them
+// Must run BEFORE any other imports that might use Buffer/process
+if (typeof window !== "undefined") {
+  (window as any).global = globalThis as any;
+  (window as any).Buffer = Buffer;
+  (window as any).process = process;
+}

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script type="module" src="/client/polyfills.ts"></script>
     <script type="module" src="/client/App.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@noble/hashes": "^2.0.1",
+    "@noble/hashes": "^1.4.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@noble/hashes':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^1.4.0
+        version: 1.4.0
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -450,6 +450,10 @@ packages:
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.4.0':
+    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -2445,6 +2449,8 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@noble/hashes@1.4.0': {}
+
   '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.1': {}
@@ -3160,7 +3166,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
       '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
+      '@noble/hashes': 1.4.0
       '@solana/buffer-layout': 4.0.1
       '@solana/codecs-numbers': 2.3.0(typescript@5.9.2)
       agentkeepalive: 4.6.0


### PR DESCRIPTION
## Purpose
Fix a runtime error that was occurring in the application by addressing compatibility issues with the @noble/hashes library and missing browser polyfills.

## Code changes
- **Downgraded @noble/hashes**: Changed from version `^2.0.1` to `^1.4.0` to resolve compatibility issues
- **Updated import paths**: Removed `.js` extensions from @noble/hashes imports in `solana-derivation.ts` to match the older version's export structure
- **Added browser polyfills**: Created `polyfills.ts` to provide Node.js globals (`Buffer`, `process`, `global`) for browser environments
- **Updated HTML**: Added polyfills script import before the main application script to ensure globals are available when needed
- **Updated lock file**: Reflected the dependency version changes and resolved package conflicts

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d6e13dedc444425e84974f83b6ba2432/zenith-home)

👀 [Preview Link](https://d6e13dedc444425e84974f83b6ba2432-zenith-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d6e13dedc444425e84974f83b6ba2432</projectId>-->
<!--<branchName>zenith-home</branchName>-->