### PR TITLE
Fix DexScreener API integration with failover endpoints

### DIFF
--- a/functions/api/[[path]].ts
+++ b/functions/api/[[path]].ts
@@ -68,7 +68,8 @@ async function tryDexscreenerEndpoints(path: string) {
   let lastError: Error | null = null;
 
   for (let i = 0; i < DEXSCREENER_ENDPOINTS.length; i++) {
-    const endpointIndex = (currentDexEndpointIndex + i) % DEXSCREENER_ENDPOINTS.length;
+    const endpointIndex =
+      (currentDexEndpointIndex + i) % DEXSCREENER_ENDPOINTS.length;
     const endpoint = DEXSCREENER_ENDPOINTS[endpointIndex];
     const url = `${endpoint}${path}`;
 
@@ -106,7 +107,9 @@ async function tryDexscreenerEndpoints(path: string) {
 }
 
 function jsonCors(status: number, body: any) {
-  const headers = applyCors(new Headers({ "Content-Type": "application/json" }));
+  const headers = applyCors(
+    new Headers({ "Content-Type": "application/json" }),
+  );
   return new Response(typeof body === "string" ? body : JSON.stringify(body), {
     status,
     headers,
@@ -138,8 +141,13 @@ export const onRequest = async ({ request, env }) => {
         return jsonCors(400, { error: "Missing 'mints' query parameter" });
       }
       const data = await tryDexscreenerEndpoints(`/tokens/${mints}`);
-      const pairs = Array.isArray(data?.pairs) ? data.pairs.filter((p: any) => p?.chainId === "solana") : [];
-      return jsonCors(200, { schemaVersion: data?.schemaVersion || "1.0.0", pairs });
+      const pairs = Array.isArray(data?.pairs)
+        ? data.pairs.filter((p: any) => p?.chainId === "solana")
+        : [];
+      return jsonCors(200, {
+        schemaVersion: data?.schemaVersion || "1.0.0",
+        pairs,
+      });
     }
 
     // DexScreener: /api/dexscreener/search?q=...
@@ -148,9 +156,16 @@ export const onRequest = async ({ request, env }) => {
       if (!q) {
         return jsonCors(400, { error: "Missing 'q' query parameter" });
       }
-      const data = await tryDexscreenerEndpoints(`/search/?q=${encodeURIComponent(q)}`);
-      const pairs = Array.isArray(data?.pairs) ? data.pairs.filter((p: any) => p?.chainId === "solana").slice(0, 20) : [];
-      return jsonCors(200, { schemaVersion: data?.schemaVersion || "1.0.0", pairs });
+      const data = await tryDexscreenerEndpoints(
+        `/search/?q=${encodeURIComponent(q)}`,
+      );
+      const pairs = Array.isArray(data?.pairs)
+        ? data.pairs.filter((p: any) => p?.chainId === "solana").slice(0, 20)
+        : [];
+      return jsonCors(200, {
+        schemaVersion: data?.schemaVersion || "1.0.0",
+        pairs,
+      });
     }
 
     // DexScreener: /api/dexscreener/trending
@@ -158,11 +173,20 @@ export const onRequest = async ({ request, env }) => {
       const data = await tryDexscreenerEndpoints(`/pairs/solana`);
       const pairs = Array.isArray(data?.pairs)
         ? data.pairs
-            .filter((p: any) => (p?.volume?.h24 || 0) > 1000 && (p?.liquidity?.usd || 0) > 10000)
-            .sort((a: any, b: any) => (b?.volume?.h24 || 0) - (a?.volume?.h24 || 0))
+            .filter(
+              (p: any) =>
+                (p?.volume?.h24 || 0) > 1000 &&
+                (p?.liquidity?.usd || 0) > 10000,
+            )
+            .sort(
+              (a: any, b: any) => (b?.volume?.h24 || 0) - (a?.volume?.h24 || 0),
+            )
             .slice(0, 50)
         : [];
-      return jsonCors(200, { schemaVersion: data?.schemaVersion || "1.0.0", pairs });
+      return jsonCors(200, {
+        schemaVersion: data?.schemaVersion || "1.0.0",
+        pairs,
+      });
     }
 
     return jsonCors(404, { error: `No handler for ${normalizedPath}` });

--- a/functions/api/[[path]].ts
+++ b/functions/api/[[path]].ts
@@ -57,6 +57,62 @@ async function proxyToSolanaRPC(
   });
 }
 
+// DexScreener endpoints for failover
+const DEXSCREENER_ENDPOINTS = [
+  "https://api.dexscreener.com/latest/dex",
+  "https://api.dexscreener.io/latest/dex",
+];
+let currentDexEndpointIndex = 0;
+
+async function tryDexscreenerEndpoints(path: string) {
+  let lastError: Error | null = null;
+
+  for (let i = 0; i < DEXSCREENER_ENDPOINTS.length; i++) {
+    const endpointIndex = (currentDexEndpointIndex + i) % DEXSCREENER_ENDPOINTS.length;
+    const endpoint = DEXSCREENER_ENDPOINTS[endpointIndex];
+    const url = `${endpoint}${path}`;
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 12000);
+      const resp = await fetch(url, {
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "User-Agent": "Mozilla/5.0 (compatible; SolanaWallet/1.0)",
+        },
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+
+      if (!resp.ok) {
+        if (resp.status === 429) continue; // rate limited -> try next
+        const t = await resp.text().catch(() => "");
+        throw new Error(`HTTP ${resp.status}: ${resp.statusText}. ${t}`);
+      }
+
+      const data = await resp.json();
+      currentDexEndpointIndex = endpointIndex;
+      return data;
+    } catch (e) {
+      lastError = e instanceof Error ? e : new Error(String(e));
+      if (i < DEXSCREENER_ENDPOINTS.length - 1) {
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    }
+  }
+
+  throw new Error(lastError?.message || "All DexScreener endpoints failed");
+}
+
+function jsonCors(status: number, body: any) {
+  const headers = applyCors(new Headers({ "Content-Type": "application/json" }));
+  return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+    status,
+    headers,
+  });
+}
+
 export const onRequest = async ({ request, env }) => {
   const url = new URL(request.url);
   const rawPath = url.pathname.replace(/^\/api/, "") || "/";
@@ -74,15 +130,44 @@ export const onRequest = async ({ request, env }) => {
     if (normalizedPath === "/solana-rpc") {
       return await proxyToSolanaRPC(request, env);
     }
-    // ...other API routing
+
+    // DexScreener: /api/dexscreener/tokens?mints=...
+    if (normalizedPath === "/dexscreener/tokens") {
+      const mints = url.searchParams.get("mints");
+      if (!mints) {
+        return jsonCors(400, { error: "Missing 'mints' query parameter" });
+      }
+      const data = await tryDexscreenerEndpoints(`/tokens/${mints}`);
+      const pairs = Array.isArray(data?.pairs) ? data.pairs.filter((p: any) => p?.chainId === "solana") : [];
+      return jsonCors(200, { schemaVersion: data?.schemaVersion || "1.0.0", pairs });
+    }
+
+    // DexScreener: /api/dexscreener/search?q=...
+    if (normalizedPath === "/dexscreener/search") {
+      const q = url.searchParams.get("q");
+      if (!q) {
+        return jsonCors(400, { error: "Missing 'q' query parameter" });
+      }
+      const data = await tryDexscreenerEndpoints(`/search/?q=${encodeURIComponent(q)}`);
+      const pairs = Array.isArray(data?.pairs) ? data.pairs.filter((p: any) => p?.chainId === "solana").slice(0, 20) : [];
+      return jsonCors(200, { schemaVersion: data?.schemaVersion || "1.0.0", pairs });
+    }
+
+    // DexScreener: /api/dexscreener/trending
+    if (normalizedPath === "/dexscreener/trending") {
+      const data = await tryDexscreenerEndpoints(`/pairs/solana`);
+      const pairs = Array.isArray(data?.pairs)
+        ? data.pairs
+            .filter((p: any) => (p?.volume?.h24 || 0) > 1000 && (p?.liquidity?.usd || 0) > 10000)
+            .sort((a: any, b: any) => (b?.volume?.h24 || 0) - (a?.volume?.h24 || 0))
+            .slice(0, 50)
+        : [];
+      return jsonCors(200, { schemaVersion: data?.schemaVersion || "1.0.0", pairs });
+    }
+
+    return jsonCors(404, { error: `No handler for ${normalizedPath}` });
   } catch (error) {
-    const headers = applyCors(
-      new Headers({ "Content-Type": "application/json" }),
-    );
     const message = error instanceof Error ? error.message : String(error);
-    return new Response(JSON.stringify({ error: message }), {
-      status: 502,
-      headers,
-    });
+    return jsonCors(502, { error: message, schemaVersion: "1.0.0", pairs: [] });
   }
 };

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -71,6 +71,47 @@ function jsonResponse(
   } as const;
 }
 
+// DexScreener failover endpoints
+const DEXSCREENER_ENDPOINTS = [
+  "https://api.dexscreener.com/latest/dex",
+  "https://api.dexscreener.io/latest/dex",
+];
+let currentDexIdx = 0;
+
+async function tryDexEndpoints(path: string) {
+  let lastError: Error | null = null;
+  for (let i = 0; i < DEXSCREENER_ENDPOINTS.length; i++) {
+    const idx = (currentDexIdx + i) % DEXSCREENER_ENDPOINTS.length;
+    const endpoint = DEXSCREENER_ENDPOINTS[idx];
+    const url = `${endpoint}${path}`;
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 12000);
+      const resp = await fetch(url, {
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "User-Agent": "Mozilla/5.0 (compatible; SolanaWallet/1.0)",
+        },
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+      if (!resp.ok) {
+        if (resp.status === 429) continue;
+        const t = await resp.text().catch(() => "");
+        throw new Error(`HTTP ${resp.status}: ${resp.statusText}. ${t}`);
+      }
+      const data = await resp.json();
+      currentDexIdx = idx;
+      return data;
+    } catch (e) {
+      lastError = e instanceof Error ? e : new Error(String(e));
+      if (i < DEXSCREENER_ENDPOINTS.length - 1) await new Promise((r) => setTimeout(r, 1000));
+    }
+  }
+  throw new Error(lastError?.message || "All DexScreener endpoints failed");
+}
+
 export const handler = async (event: any) => {
   // Handle CORS preflight
   if (event.httpMethod === "OPTIONS") {
@@ -81,6 +122,7 @@ export const handler = async (event: any) => {
     (event.path || "").replace(/^\/.netlify\/functions\/api/, "") || "/";
 
   try {
+    // Solana RPC
     if (path === "/solana-rpc" && event.httpMethod === "POST") {
       let body: any = {};
       try {
@@ -99,11 +141,43 @@ export const handler = async (event: any) => {
       return jsonResponse(200, result.body);
     }
 
+    // DexScreener: tokens
+    if (path === "/dexscreener/tokens" && event.httpMethod === "GET") {
+      const mints = event.queryStringParameters?.mints;
+      if (!mints) return jsonResponse(400, { error: "Missing 'mints' query parameter" });
+      const data = await tryDexEndpoints(`/tokens/${mints}`);
+      const pairs = Array.isArray(data?.pairs) ? data.pairs.filter((p: any) => p?.chainId === "solana") : [];
+      return jsonResponse(200, { schemaVersion: data?.schemaVersion || "1.0.0", pairs });
+    }
+
+    // DexScreener: search
+    if (path === "/dexscreener/search" && event.httpMethod === "GET") {
+      const q = event.queryStringParameters?.q;
+      if (!q) return jsonResponse(400, { error: "Missing 'q' query parameter" });
+      const data = await tryDexEndpoints(`/search/?q=${encodeURIComponent(q)}`);
+      const pairs = Array.isArray(data?.pairs) ? data.pairs.filter((p: any) => p?.chainId === "solana").slice(0, 20) : [];
+      return jsonResponse(200, { schemaVersion: data?.schemaVersion || "1.0.0", pairs });
+    }
+
+    // DexScreener: trending
+    if (path === "/dexscreener/trending" && event.httpMethod === "GET") {
+      const data = await tryDexEndpoints(`/pairs/solana`);
+      const pairs = Array.isArray(data?.pairs)
+        ? data.pairs
+            .filter((p: any) => (p?.volume?.h24 || 0) > 1000 && (p?.liquidity?.usd || 0) > 10000)
+            .sort((a: any, b: any) => (b?.volume?.h24 || 0) - (a?.volume?.h24 || 0))
+            .slice(0, 50)
+        : [];
+      return jsonResponse(200, { schemaVersion: data?.schemaVersion || "1.0.0", pairs });
+    }
+
     // Unknown API route
     return jsonResponse(404, { error: `No handler for ${path}` });
   } catch (error) {
     return jsonResponse(502, {
       error: error instanceof Error ? error.message : String(error),
+      schemaVersion: "1.0.0",
+      pairs: [],
     });
   }
 };

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -106,7 +106,8 @@ async function tryDexEndpoints(path: string) {
       return data;
     } catch (e) {
       lastError = e instanceof Error ? e : new Error(String(e));
-      if (i < DEXSCREENER_ENDPOINTS.length - 1) await new Promise((r) => setTimeout(r, 1000));
+      if (i < DEXSCREENER_ENDPOINTS.length - 1)
+        await new Promise((r) => setTimeout(r, 1000));
     }
   }
   throw new Error(lastError?.message || "All DexScreener endpoints failed");
@@ -144,19 +145,31 @@ export const handler = async (event: any) => {
     // DexScreener: tokens
     if (path === "/dexscreener/tokens" && event.httpMethod === "GET") {
       const mints = event.queryStringParameters?.mints;
-      if (!mints) return jsonResponse(400, { error: "Missing 'mints' query parameter" });
+      if (!mints)
+        return jsonResponse(400, { error: "Missing 'mints' query parameter" });
       const data = await tryDexEndpoints(`/tokens/${mints}`);
-      const pairs = Array.isArray(data?.pairs) ? data.pairs.filter((p: any) => p?.chainId === "solana") : [];
-      return jsonResponse(200, { schemaVersion: data?.schemaVersion || "1.0.0", pairs });
+      const pairs = Array.isArray(data?.pairs)
+        ? data.pairs.filter((p: any) => p?.chainId === "solana")
+        : [];
+      return jsonResponse(200, {
+        schemaVersion: data?.schemaVersion || "1.0.0",
+        pairs,
+      });
     }
 
     // DexScreener: search
     if (path === "/dexscreener/search" && event.httpMethod === "GET") {
       const q = event.queryStringParameters?.q;
-      if (!q) return jsonResponse(400, { error: "Missing 'q' query parameter" });
+      if (!q)
+        return jsonResponse(400, { error: "Missing 'q' query parameter" });
       const data = await tryDexEndpoints(`/search/?q=${encodeURIComponent(q)}`);
-      const pairs = Array.isArray(data?.pairs) ? data.pairs.filter((p: any) => p?.chainId === "solana").slice(0, 20) : [];
-      return jsonResponse(200, { schemaVersion: data?.schemaVersion || "1.0.0", pairs });
+      const pairs = Array.isArray(data?.pairs)
+        ? data.pairs.filter((p: any) => p?.chainId === "solana").slice(0, 20)
+        : [];
+      return jsonResponse(200, {
+        schemaVersion: data?.schemaVersion || "1.0.0",
+        pairs,
+      });
     }
 
     // DexScreener: trending
@@ -164,11 +177,20 @@ export const handler = async (event: any) => {
       const data = await tryDexEndpoints(`/pairs/solana`);
       const pairs = Array.isArray(data?.pairs)
         ? data.pairs
-            .filter((p: any) => (p?.volume?.h24 || 0) > 1000 && (p?.liquidity?.usd || 0) > 10000)
-            .sort((a: any, b: any) => (b?.volume?.h24 || 0) - (a?.volume?.h24 || 0))
+            .filter(
+              (p: any) =>
+                (p?.volume?.h24 || 0) > 1000 &&
+                (p?.liquidity?.usd || 0) > 10000,
+            )
+            .sort(
+              (a: any, b: any) => (b?.volume?.h24 || 0) - (a?.volume?.h24 || 0),
+            )
             .slice(0, 50)
         : [];
-      return jsonResponse(200, { schemaVersion: data?.schemaVersion || "1.0.0", pairs });
+      return jsonResponse(200, {
+        schemaVersion: data?.schemaVersion || "1.0.0",
+        pairs,
+      });
     }
 
     // Unknown API route


### PR DESCRIPTION
## Purpose

The user reported that the DexScreener API was not working to fetch real token data, while SOL coin balance and other functions were working properly. This fix addresses the DexScreener API integration issues to ensure reliable token data fetching.

## Code changes

- **Added DexScreener failover endpoints**: Implemented multiple API endpoints (`api.dexscreener.com` and `api.dexscreener.io`) with automatic failover logic
- **Implemented retry mechanism**: Added `tryDexscreenerEndpoints()` function with timeout handling (12s), rate limit detection, and error recovery
- **Added three new API routes**:
  - `/api/dexscreener/tokens` - Fetch token data by mint addresses
  - `/api/dexscreener/search` - Search tokens by query
  - `/api/dexscreener/trending` - Get trending Solana pairs with volume/liquidity filtering
- **Enhanced error handling**: Improved error responses with consistent JSON format and CORS headers
- **Applied changes to both platforms**: Updated both Cloudflare Functions (`functions/api/[[path]].ts`) and Netlify Functions (`netlify/functions/api.ts`) for consistency

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d6e13dedc444425e84974f83b6ba2432/aura-den)

👀 [Preview Link](https://d6e13dedc444425e84974f83b6ba2432-aura-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d6e13dedc444425e84974f83b6ba2432</projectId>-->
<!--<branchName>aura-den</branchName>-->