### PR TITLE
Fix SOL balance NaN display with proper type checking

### DIFF
--- a/client/components/Swap.tsx
+++ b/client/components/Swap.tsx
@@ -13,7 +13,7 @@ export default function Swap({ wallet }) {
   return (
     <div className="p-4">
       <h2 className="text-lg font-semibold">Wallet Swap</h2>
-      <p>Balance: {balance / 1e9} SOL</p>
+      <p>Balance: {balance} SOL</p>
     </div>
   );
 }

--- a/client/lib/services/helius.ts
+++ b/client/lib/services/helius.ts
@@ -202,10 +202,17 @@ class HeliusAPI {
   async getWalletBalance(publicKey: string): Promise<number> {
     try {
       console.log(`Fetching SOL balance for ${publicKey} via Helius...`);
-      const lamports = await this.makeRpcCall("getBalance", [publicKey]);
-      const balance = lamports / 1000000000; // Convert lamports to SOL
-      console.log(`SOL balance: ${balance}`);
-      return balance;
+      const res = await this.makeRpcCall("getBalance", [publicKey]);
+      const lamports =
+        typeof res === "number"
+          ? res
+          : typeof (res as any)?.value === "number"
+            ? (res as any).value
+            : 0;
+      const balance = lamports / 1_000_000_000; // Convert lamports to SOL
+      const safe = Number.isFinite(balance) ? balance : 0;
+      console.log(`SOL balance: ${safe}`);
+      return safe;
     } catch (error) {
       console.error("Error fetching wallet balance via Helius:", error);
       throw error;

--- a/client/lib/services/solana-rpc.ts
+++ b/client/lib/services/solana-rpc.ts
@@ -71,11 +71,14 @@ export const makeRpcCall = async (
           });
         } catch (fetchErr) {
           // Network/connection error (e.g. Dev server not running, middleware not mounted)
-          const fetchError = fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
+          const fetchError =
+            fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
 
           // Health check to provide better guidance
           try {
-            const health = await fetch("/api/health").then((r) => r.text()).catch(() => "");
+            const health = await fetch("/api/health")
+              .then((r) => r.text())
+              .catch(() => "");
             throw new Error(
               `Network fetch failed: ${fetchError}. API health check: ${health || "no response"}`,
             );
@@ -94,18 +97,29 @@ export const makeRpcCall = async (
             parsedErr = responseText ? JSON.parse(responseText) : null;
           } catch {}
 
-          const details = parsedErr?.error?.message || parsedErr?.message || responseText || response.statusText || "(no response body)";
+          const details =
+            parsedErr?.error?.message ||
+            parsedErr?.message ||
+            responseText ||
+            response.statusText ||
+            "(no response body)";
 
           // If server-provided diagnostics endpoint exists, attempt to fetch and append
           let serverDiag = "";
           if (response.status === 500) {
             try {
-              serverDiag = await fetch("/api/debug/rpc").then((d) => d.text()).catch(() => "");
+              serverDiag = await fetch("/api/debug/rpc")
+                .then((d) => d.text())
+                .catch(() => "");
             } catch {}
           }
 
-          const diagSuffix = serverDiag ? ` Server diagnostics: ${serverDiag}` : "";
-          throw new Error(`RPC call failed: ${response.status} ${response.statusText}. ${details}${diagSuffix}`);
+          const diagSuffix = serverDiag
+            ? ` Server diagnostics: ${serverDiag}`
+            : "";
+          throw new Error(
+            `RPC call failed: ${response.status} ${response.statusText}. ${details}${diagSuffix}`,
+          );
         }
 
         // Try to parse response as JSON, if not available return raw text
@@ -118,7 +132,9 @@ export const makeRpcCall = async (
         }
 
         if (data && data.error) {
-          throw new Error(`RPC error: ${data.error.message} (code: ${data.error.code || "unknown"})`);
+          throw new Error(
+            `RPC error: ${data.error.message} (code: ${data.error.code || "unknown"})`,
+          );
         }
 
         return data?.result ?? data ?? text;
@@ -126,12 +142,16 @@ export const makeRpcCall = async (
         lastError = error instanceof Error ? error : new Error(String(error));
 
         if (attempt < retries) {
-          await new Promise((resolve) => setTimeout(resolve, 1000 * (attempt + 1)));
+          await new Promise((resolve) =>
+            setTimeout(resolve, 1000 * (attempt + 1)),
+          );
         }
       }
     }
 
-    throw new Error(`RPC call failed after ${retries + 1} attempts: ${lastError?.message || "Unknown error"}`);
+    throw new Error(
+      `RPC call failed after ${retries + 1} attempts: ${lastError?.message || "Unknown error"}`,
+    );
   })();
 
   requestQueue.set(requestKey, requestPromise);

--- a/client/lib/services/solana-rpc.ts
+++ b/client/lib/services/solana-rpc.ts
@@ -149,8 +149,15 @@ export const makeRpcCall = async (
  */
 export const getWalletBalance = async (publicKey: string): Promise<number> => {
   try {
-    const balance = await makeRpcCall("getBalance", [publicKey]);
-    return balance / 1_000_000_000;
+    const res = await makeRpcCall("getBalance", [publicKey]);
+    const lamports =
+      typeof res === "number"
+        ? res
+        : typeof (res as any)?.value === "number"
+          ? (res as any).value
+          : 0;
+    const sol = lamports / 1_000_000_000;
+    return Number.isFinite(sol) ? sol : 0;
   } catch (error) {
     console.error("Error fetching wallet balance:", error);
     return 0;

--- a/client/lib/services/transaction-monitor.ts
+++ b/client/lib/services/transaction-monitor.ts
@@ -251,11 +251,12 @@ class TransactionMonitor {
         if (walletIndex !== -1) {
           const preBalance = transaction.meta.preBalances[walletIndex];
           const postBalance = transaction.meta.postBalances[walletIndex];
-          const difference = (postBalance - preBalance) / 1e9; // Convert lamports to SOL
-
-          if (Math.abs(difference) > 0) {
-            notification.amount = Math.abs(difference);
-            notification.token = "SOL";
+          if (typeof preBalance === "number" && typeof postBalance === "number") {
+            const difference = (postBalance - preBalance) / 1e9; // Convert lamports to SOL
+            if (Number.isFinite(difference) && Math.abs(difference) > 0) {
+              notification.amount = Math.abs(difference);
+              notification.token = "SOL";
+            }
           }
         }
       }

--- a/client/lib/services/transaction-monitor.ts
+++ b/client/lib/services/transaction-monitor.ts
@@ -251,7 +251,10 @@ class TransactionMonitor {
         if (walletIndex !== -1) {
           const preBalance = transaction.meta.preBalances[walletIndex];
           const postBalance = transaction.meta.postBalances[walletIndex];
-          if (typeof preBalance === "number" && typeof postBalance === "number") {
+          if (
+            typeof preBalance === "number" &&
+            typeof postBalance === "number"
+          ) {
             const difference = (postBalance - preBalance) / 1e9; // Convert lamports to SOL
             if (Number.isFinite(difference) && Math.abs(difference) > 0) {
               notification.amount = Math.abs(difference);


### PR DESCRIPTION
## Purpose

The user reported that the Solana RPC was showing "NaN sol" instead of the actual SOL balance. This indicates that the balance calculation was receiving invalid or unexpected data types from the RPC response, resulting in NaN (Not a Number) values being displayed to the user.

## Code changes

- **Enhanced type safety in balance fetching**: Added proper type checking for RPC responses in both `helius.ts` and `solana-rpc.ts` to handle cases where the response structure might vary
- **Improved lamports conversion**: Updated balance calculation logic to safely extract lamports value from either direct number responses or nested object responses with a `value` property
- **Added NaN protection**: Implemented `Number.isFinite()` checks to ensure only valid numbers are returned, defaulting to 0 for invalid values
- **Updated transaction monitoring**: Enhanced balance difference calculations with proper type checking to prevent NaN values in transaction notifications
- **Removed redundant division**: Fixed display component to show balance directly instead of dividing by 1e9 again (conversion now handled in the service layer)

These changes ensure that SOL balances are always displayed as valid numbers, preventing the "NaN sol" issue reported by the user.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d6e13dedc444425e84974f83b6ba2432/swoosh-studio)

👀 [Preview Link](https://d6e13dedc444425e84974f83b6ba2432-swoosh-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d6e13dedc444425e84974f83b6ba2432</projectId>-->
<!--<branchName>swoosh-studio</branchName>-->